### PR TITLE
r8

### DIFF
--- a/CatConfig/IComplexUnit.cs
+++ b/CatConfig/IComplexUnit.cs
@@ -1,0 +1,3 @@
+﻿namespace CatConfig;
+
+public interface IComplexUnit : IUnit;

--- a/CatConfig/IDelayedProcessor.cs
+++ b/CatConfig/IDelayedProcessor.cs
@@ -1,0 +1,9 @@
+﻿namespace CatConfig;
+
+public interface IDelayedProcessor
+{
+	string Name { get; }
+	string ProtocolSchema { get; }
+
+	IUnit ResolveDelayedUnit(IDelayedUnit delayed);
+}

--- a/CatConfig/IDelayedUnit.cs
+++ b/CatConfig/IDelayedUnit.cs
@@ -1,0 +1,10 @@
+﻿namespace CatConfig;
+
+public interface IDelayedUnit : IComplexUnit
+{
+	string Name { get; }
+	string GetHostName();
+	string GetProtocolSchema();
+	string GetPath();
+	IDelayedUnit ResolveUrl(Func<int, string, string, IUnitRecord> resolver, string[] fields);
+}

--- a/CatConfig/IEmptyUnit.cs
+++ b/CatConfig/IEmptyUnit.cs
@@ -1,0 +1,3 @@
+﻿namespace CatConfig;
+
+public interface IEmptyUnit : IUnit;

--- a/CatConfig/IUnit.cs
+++ b/CatConfig/IUnit.cs
@@ -1,0 +1,6 @@
+﻿namespace CatConfig;
+
+public interface IUnit
+{
+	int Id { get; }
+}

--- a/CatConfig/IUnitArray.cs
+++ b/CatConfig/IUnitArray.cs
@@ -1,0 +1,6 @@
+﻿namespace CatConfig;
+
+public interface IUnitArray : IUnit
+{
+	IUnit[] Elements { get; }
+}

--- a/CatConfig/IUnitRecord.cs
+++ b/CatConfig/IUnitRecord.cs
@@ -1,0 +1,11 @@
+﻿namespace CatConfig;
+
+public delegate IUnit Function(params object[] args);
+public interface IUnitRecord : IComplexUnit
+{
+	string Name { get; }
+	string[] FieldNames { get; }
+
+	Function this[IDelayedUnit field] { get; }
+	IUnit this[string fieldName] { get; }
+}

--- a/CatConfig/IUnitValue.cs
+++ b/CatConfig/IUnitValue.cs
@@ -1,0 +1,6 @@
+﻿namespace CatConfig;
+
+public interface IUnitValue : IUnit
+{
+	string Value { get; }
+}

--- a/CatConfig/NoRecord.cs
+++ b/CatConfig/NoRecord.cs
@@ -1,0 +1,16 @@
+﻿namespace CatConfig;
+
+public record NoRecord : IUnitRecord
+{
+
+	private readonly NoValue noUnit = new();
+	public IUnit this[string fieldName] => noUnit;
+
+	public IUnit this[(string field, string[] args) a] => noUnit;
+
+	public Function this[IDelayedUnit field] => _ => noUnit;
+
+	public string Name => nameof(NoRecord);
+	public string[] FieldNames => [];
+	public int Id => -1;
+}

--- a/CatConfig/NoValue.cs
+++ b/CatConfig/NoValue.cs
@@ -1,0 +1,5 @@
+﻿namespace CatConfig;
+
+public record NoValue(int Id = 0) : IUnit;
+public record EmptyValue(int Id) : IUnit, IEmptyUnit;
+

--- a/CatConfig/Parser.cs
+++ b/CatConfig/Parser.cs
@@ -71,7 +71,7 @@ public class Parser
 		index = int.Clamp(index, -1, 0);
 
 		Ccl tree = new(index, 0, path);
-		ParserHelpers.Parse(content, tree, delimiter, indent, indentStep);
+		ParserHelpers.Parse(content,tree, delimiter, indent, indentStep);
 
 		return Constructor.GetStructure(tree, parser);
 	}

--- a/CatConfig/ParserHelpers.cs
+++ b/CatConfig/ParserHelpers.cs
@@ -304,18 +304,19 @@ internal static class ParserHelpers
 				{
 					Ccl child = new(keyStart, level, key);
 
-					if (!parent.Items.TryAdd(key, new([child])))
-						parent.Items[key].Add(child);
-
-					Ccl p = parent;
-
 					if (nextLevel > level)
 					{
-						p = child;
+						index = Parse(ccl,  child, delimiter, indent, indentStep, index, nextLevel);
 					}
+					else
+					{
+						index = Parse(ccl,  parent, delimiter, indent, indentStep, index, nextLevel);
 
 
-					index = Parse(ccl, p, delimiter, indent, indentStep, index, nextLevel);
+					}
+						if (!parent.Items.TryAdd(key, [child]))
+							parent.Items[key].Add(child);
+
 				}
 			}
 		}

--- a/CatConfig/UnitArray.cs
+++ b/CatConfig/UnitArray.cs
@@ -1,0 +1,3 @@
+﻿namespace CatConfig;
+
+public record UnitArray(int Id, IUnit[] Elements) : IUnitArray, IComplexUnit;

--- a/CatConfig/UnitRecord.cs
+++ b/CatConfig/UnitRecord.cs
@@ -1,0 +1,76 @@
+﻿namespace CatConfig;
+
+public class UnitRecord : IUnitRecord
+{
+	private readonly NoValue noUnit;
+	private readonly Dictionary<string, IUnit> tree;
+	private readonly Func<IDelayedUnit, IUnit> resolve;
+
+	public UnitRecord(int id, string name, Dictionary<string, IUnit> tree, Func<IDelayedUnit, IUnit> resolver)
+	{
+		Id = id;
+		FieldNames = tree.Keys.ToArray();
+		Name = name;
+		this.resolve = resolver;
+		this.tree = new(tree, StringComparer.OrdinalIgnoreCase);
+		noUnit = new();
+	}
+
+	public int Id { get; }
+	public string Name { get; }
+	public string[] FieldNames { get; }
+	public IUnit this[string fieldName] => GetUnitValue(fieldName);
+	public Function this[IDelayedUnit field] => (args) => GetUnitValue(field, args);
+
+	private IUnit GetUnitValue(IDelayedUnit field, object[] param)
+	{
+		string fieldName = field.Name;
+		string[] args = param.Select(o => o.ToString() ?? "").ToArray();
+		var val = tree.GetValueOrDefault(fieldName, tree.GetValueOrDefault('{' + fieldName + '}', noUnit));
+		var delayed = val as IDelayedUnit;
+
+		if (delayed == null)
+			return noUnit;
+
+
+		Func<int, string, string, IUnitRecord> resolver = (id, name, path)
+			=> new UnitRecord(
+				id,
+				name,
+				new Dictionary<string, IUnit>() { { "URL", new UnitValue(id, path) } },
+				resolve);
+
+		delayed = delayed.ResolveUrl(resolver, args);
+
+		//if (fieldName.FirstOrDefault() != '{' && fieldName.LastOrDefault() != '}')
+		return resolve(delayed);
+
+
+	}
+
+	private IUnit GetUnitValue(string fieldName)
+	{
+		var val = tree.GetValueOrDefault(fieldName, tree.GetValueOrDefault('{' + fieldName + '}', noUnit));
+
+		if (val is IDelayedUnit delayed && fieldName.FirstOrDefault() != '{' && fieldName.LastOrDefault() != '}')
+			val = resolve(delayed);
+
+		return val;
+	}
+
+	public IUnitRecord Await(IDelayedUnit delayed, string urlPath)
+	{
+		var url = new UnitValue(delayed.Id, urlPath);
+		var dic = new Dictionary<string, IUnit>() { { "URL", url } };
+		return new UnitRecord(delayed.Id, delayed.Name, dic, resolve);
+	}
+
+
+	public Func<int, string, IUnitRecord> Await(int id, string urlPath)
+	{
+		var url = new UnitValue(id, urlPath);
+		var dic = new Dictionary<string, IUnit>() { { "URL", url } };
+		return (i, s) => new UnitRecord(i, s, dic, resolve);
+	}
+
+}

--- a/CatConfig/UnitValue.cs
+++ b/CatConfig/UnitValue.cs
@@ -1,0 +1,3 @@
+﻿namespace CatConfig;
+
+public record UnitValue(int Id, string Value) : IUnitValue;

--- a/CclSharp.Test/DelayedUnitTests.cs
+++ b/CclSharp.Test/DelayedUnitTests.cs
@@ -15,7 +15,8 @@ namespace CclSharp.Test
 		{
 			Constructor.RegisterProcessor(new TestUnitProcessor());
 		}
-		static string url = "test://Test/{x}/{y}";
+
+		static string url = "test://Test/{x}+{y}";
 		static string lorem =
 		"""
 		Interdum  =
@@ -27,14 +28,14 @@ namespace CclSharp.Test
 
 		static string delayed = '\n' +
 		$$"""
-			{Nunc} = 
+			{Sum} = 
 				URL = {{url}}
 				x = 10
 				y = 5
 		""" + '\n';
 
 
-		static string ipsum = "\tEtiam = _ -> true;";
+		static string ipsum = "\tEtiam = true";
 		static string test = lorem + delayed + ipsum;
 
 		[Fact]
@@ -49,7 +50,7 @@ namespace CclSharp.Test
 			Assert.NotNull(rec);
 
 
-			var value = rec["{Nunc}"];
+			var value = rec["Sum"];
 			var unit = value as IUnitValue;
 
 			Assert.NotNull(unit);
@@ -58,7 +59,25 @@ namespace CclSharp.Test
 
 		}
 
+		[Fact]
+		public void TestDelayedUnitParameter()
+		{
 
+			var parser = Parser.FromContent("", test);
+			var structure = parser.ParseContent("", test);
+			var rec = structure as UnitRecord;
+
+			Assert.NotNull(rec);
+
+			var wait = rec["{Sum}"] as IDelayedUnit;
+			Assert.NotNull(wait);
+
+			var unit = rec[wait](7, 4) as IUnitValue;
+			Assert.NotNull(unit);
+
+			Assert.Equal("11", unit.Value);
+
+		}
 	}
 }
 

--- a/CclSharp.Test/TestUnitProcessor.cs
+++ b/CclSharp.Test/TestUnitProcessor.cs
@@ -2,7 +2,7 @@
 
 namespace CclSharp.Test
 {
-	public class TestUnitProcessor : IDelayedProcessor, IDelayedAccessor
+	public class TestUnitProcessor : IDelayedProcessor
 	{
 		private NoValue noValue = new NoValue();
 
@@ -24,22 +24,36 @@ namespace CclSharp.Test
 			if (!delayed.GetProtocolSchema().Equals(ProtocolSchema, StringComparison.OrdinalIgnoreCase))
 				return noValue;
 
-			delayed.GetHostRecord(this);
+			string parseX = "";
+			string parseY = "";
 
-			if (!entities.TryGetValue(delayed.Id, out var urlRecord))
-				return noValue;
-
-
-			var xUnit = urlRecord["x"] as IUnitValue;
-			var yUnit = urlRecord["y"] as IUnitValue;
 			int x = 0;
 			int y = 0;
 
-			if (xUnit != null && yUnit != null)
+			string path = delayed.GetPath();
+			int i = 0;
+			int phase = 0;
+
+			while (i < path.Length)
 			{
-				int.TryParse(xUnit.Value, out x);
-				int.TryParse(yUnit.Value, out y);
+				char c = path[i];
+
+				if (phase == 0)
+				{
+					if (c == '+')
+						phase = 1;
+					else
+						parseX += c;
+				}
+				else
+				{
+					parseY += c;
+				}
+				i++;
 			}
+
+			int.TryParse(parseX, out x);
+			int.TryParse(parseY, out y);
 
 			return new UnitValue(delayed.Id, (x + y).ToString());
 

--- a/revision.txt
+++ b/revision.txt
@@ -48,3 +48,11 @@ r7	The GetStructure method passes the parser on, eventually to a DelayedUnit whi
 r7	Added test to run through delayed unit scenario (basically an x + y function)
 r7	Added IDelayedUnit GetHostRecord(accesor) method
 r7	Added IDelayedUnit GetHostName(), GetProtocolSchema(), GetPath() methods
+r8	DelayedUnit now requires a Func<IUnitRecor> instead of a Parser
+r8	DelayedUnit.GetHostRecord method removed 
+r8	DelayedUnit.ResolveUrl method will allow interpolated values to be provided "on the fly"
+r8	DelayedUnit.Interpolate bug fix - UnitValue.Value not IUnit.ToString() when resolving a ccl provided value
+r8	Broke classes and interfaces from Constructor.cs into their own files
+r8	ParserHelper Parse method updated to no set new instance when passing in "parent" recursively, we now call the method in both branches of an if/else
+r8	DelayedUnitTests updated to test for providing values on the fly - changed name of field to "Sum" and the path now uses a plus sign
+r8	TestUnitProcessor now parses the path to get the two integer numbers on either side of the plus sign


### PR DESCRIPTION
r8	DelayedUnit now requires a Func<IUnitRecor> instead of a Parser
r8	DelayedUnit.GetHostRecord method removed 
r8	DelayedUnit.ResolveUrl method will allow interpolated values to be provided "on the fly"
r8	DelayedUnit.Interpolate bug fix - UnitValue.Value not IUnit.ToString() when resolving a ccl provided value
r8	Broke classes and interfaces from Constructor.cs into their own files
r8	ParserHelper Parse method updated to no set new instance when passing in "parent" recursively, we now call the method in both branches of an if/else
r8	DelayedUnitTests updated to test for providing values on the fly - changed name of field to "Sum" and the path now uses a plus sign
r8	TestUnitProcessor now parses the path to get the two integer numbers on either side of the plus sign