### PR TITLE
Dev

### DIFF
--- a/CatConfig/Abstraction/IDelayedUnit.cs
+++ b/CatConfig/Abstraction/IDelayedUnit.cs
@@ -11,4 +11,5 @@ public interface IDelayedUnit : IComplexUnit
     UnitPath GetPath(char qtExpand);
     int GetArity();
     string ResolveUrl(params string[] parameters);
+	IDelayedUnit Resolve(IUnitRecord imports);
 }

--- a/CatConfig/Abstraction/IUnitRecord.cs
+++ b/CatConfig/Abstraction/IUnitRecord.cs
@@ -9,4 +9,5 @@ public interface IUnitRecord : IComplexUnit
 
     Function this[IDelayedUnit field] { get; }
     IUnit this[string fieldName] { get; }
+	IUnitRecord Transform(IUnitRecord import, bool @override = false);
 }

--- a/CatConfig/CclUnit/DelayedUnit.cs
+++ b/CatConfig/CclUnit/DelayedUnit.cs
@@ -114,5 +114,9 @@ public class DelayedUnit : IDelayedUnit
 
         return result;
     }
-
+	public IDelayedUnit Resolve(IUnitRecord imports)
+	{
+		var record = getRecord();
+		return new DelayedUnit(Id, Name, () => record.Transform(imports));
+	}
 }

--- a/CatConfig/CclUnit/NoRecord.cs
+++ b/CatConfig/CclUnit/NoRecord.cs
@@ -14,4 +14,6 @@ public record NoRecord : IUnitRecord
     public string Name => nameof(NoRecord);
     public string[] FieldNames => [];
     public int Id => -1;
+
+	public IUnitRecord Transform(IUnitRecord import, bool @override = false) => this;
 }

--- a/CatConfig/CclUnit/UnitRecord.cs
+++ b/CatConfig/CclUnit/UnitRecord.cs
@@ -4,64 +4,63 @@ namespace CatConfig.CclUnit;
 
 public class UnitRecord : IUnitRecord
 {
-    private readonly NoValue noUnit;
-    private readonly Dictionary<string, IUnit> tree;
-    private readonly Func<IDelayedUnit, IUnit> resolve;
+	private readonly NoValue noUnit;
+	private readonly Dictionary<string, IUnit> tree;
+	private readonly Func<IDelayedUnit, IUnit> resolve;
 
-    public UnitRecord(int id, string name, Dictionary<string, IUnit> tree, Func<IDelayedUnit, IUnit> resolver)
-    {
-        Id = id;
-        FieldNames = tree.Keys.ToArray();
-        this.tree = new(tree, StringComparer.OrdinalIgnoreCase);
-        Name = name;
-        resolve = resolver;
-        noUnit = new();
-    }
+	public UnitRecord(int id, string name, Dictionary<string, IUnit> tree, Func<IDelayedUnit, IUnit> resolver)
+	{
+		Id = id;
+		FieldNames = tree.Keys.ToArray();
+		this.tree = new(tree, StringComparer.OrdinalIgnoreCase);
+		Name = name;
+		resolve = resolver;
+		noUnit = new();
+	}
 
-    public int Id { get; }
-    public string Name { get; }
-    public string[] FieldNames { get; }
-    public IUnit this[string fieldName] => GetUnitValue(fieldName);
-    public Function this[IDelayedUnit field] => (args) => GetUnitValue(field, args);
+	public int Id { get; }
+	public string Name { get; }
+	public string[] FieldNames { get; }
+	public IUnit this[string fieldName] => GetUnitValue(fieldName);
+	public Function this[IDelayedUnit field] => (args) => GetUnitValue(field, args);
 
 
-    private IUnit GetUnitValue(IDelayedUnit field, object[] param)
-    {
-        string fieldName = field.Name;
-        string[] args = param.Select(o => o.ToString() ?? "").ToArray();
-        var val = tree.GetValueOrDefault(fieldName, tree.GetValueOrDefault('{' + fieldName + '}', noUnit));
-        var delayed = val as IDelayedUnit;
+	private IUnit GetUnitValue(IDelayedUnit field, object[] param)
+	{
+		string fieldName = field.Name;
+		string[] args = param.Select(o => o.ToString() ?? "").ToArray();
+		var val = tree.GetValueOrDefault(fieldName, tree.GetValueOrDefault('{' + fieldName + '}', noUnit));
+		var delayed = val as IDelayedUnit;
 
-        if (delayed == null)
-            return noUnit;
+		if (delayed == null)
+			return noUnit;
 
 		delayed = field;
-        if (delayed.GetArity() > 0 || param.Length > 0)
-        {
-            string path = delayed.ResolveUrl(args);
-            var dic = new Dictionary<string, IUnit>(StringComparer.OrdinalIgnoreCase) { { "URL", new UnitValue(delayed.Id, path) } };
-            delayed = new DelayedUnit(delayed.Id, delayed.Name, () => new UnitRecord(delayed.Id, delayed.Name, dic, resolve));
-        }
+
+		string path = delayed.ResolveUrl(args);
+		var dic = new Dictionary<string, IUnit>(StringComparer.OrdinalIgnoreCase) { { "URL", new UnitValue(delayed.Id, path) } };
+		delayed = new DelayedUnit(delayed.Id, delayed.Name, () => new UnitRecord(delayed.Id, delayed.Name, dic, resolve));
 
 
-        if (delayed.GetArity() > 0)
-            return noUnit;
 
-        return resolve(delayed);
-    }
+		if (delayed.GetArity() > 0)
+			return noUnit;
 
-    private IUnit GetUnitValue(string fieldName)
-    {
-        var val = tree.GetValueOrDefault(fieldName, tree.GetValueOrDefault('{' + fieldName + '}', noUnit));
+		return resolve(delayed);
+	}
 
-        if (val is IDelayedUnit delayed && !ParserHelpers.IsDelayedValue(fieldName) && delayed.GetArity() == 0)
-            val = resolve(delayed);
+	private IUnit GetUnitValue(string fieldName)
+	{
+		var val = tree.GetValueOrDefault(fieldName, tree.GetValueOrDefault('{' + fieldName + '}', noUnit));
 
-        return val;
-    }
+		if (val is IDelayedUnit delayed && !ParserHelpers.IsDelayedValue(fieldName) && delayed.GetArity() == 0)
+			val = resolve(delayed);
+
+		return val;
+	}
 	public IUnitRecord Transform(IUnitRecord import, bool @override = false)
 	{
-		var tree = this.tree.ToDictionary();
+		var tree = this.tree.ToDictionary(StringComparer.OrdinalIgnoreCase);
 
 		foreach (var field in import.FieldNames)
 			if (tree.TryGetValue(field, out var unit))

--- a/CatConfig/CclUnit/UnitRecord.cs
+++ b/CatConfig/CclUnit/UnitRecord.cs
@@ -35,6 +35,7 @@ public class UnitRecord : IUnitRecord
         if (delayed == null)
             return noUnit;
 
+		delayed = field;
         if (delayed.GetArity() > 0 || param.Length > 0)
         {
             string path = delayed.ResolveUrl(args);
@@ -58,6 +59,20 @@ public class UnitRecord : IUnitRecord
 
         return val;
     }
+	public IUnitRecord Transform(IUnitRecord import, bool @override = false)
+	{
+		var tree = this.tree.ToDictionary();
+
+		foreach (var field in import.FieldNames)
+			if (tree.TryGetValue(field, out var unit))
+				if (@override || unit is IEmptyUnit)
+					tree[field] = import[field];
+
+
+		var result = new UnitRecord(Id, Name, tree, resolve);
+
+		return result;
+	}
 
 
 }

--- a/CclSharp.Test/DelayedUnitTests.cs
+++ b/CclSharp.Test/DelayedUnitTests.cs
@@ -6,17 +6,17 @@ using static CclSharp.Test.TestHelpers;
 namespace CclSharp.Test
 {
 
-    public class DelayedUnitTests
-    {
-        public DelayedUnitTests()
-        {
-            Constructor.RegisterProcessor(new TestSumIntegerUnitProcessor());
-            Constructor.RegisterProcessor(new TestOrderQuantityLookupProcessor());
-        }
+	public class DelayedUnitTests
+	{
+		public DelayedUnitTests()
+		{
+			Constructor.RegisterProcessor(new TestSumIntegerUnitProcessor());
+			Constructor.RegisterProcessor(new TestOrderQuantityLookupProcessor());
+		}
 
-        static string url = "test://Sum/{x}+{y}";
-        static string lorem =
-        """
+		static string url = "test://Sum/{x}+{y}";
+		static string lorem =
+		"""
 		Interdum  =
 			Vestibulum  = 'non'
 			Neque = '*.*'
@@ -24,64 +24,64 @@ namespace CclSharp.Test
 			Morbi = 'enim'
 		""";
 
-        static string delayed(string x, string y) => '\n' +
-        $$"""
+		static string delayed(string x, string y) => '\n' +
+		$$"""
 			{Sum} = 
 				URL = {{url}}
 				x = {{x}}
 				y = {{y}}
 		""" + '\n';
-        static string ipsum = "\tEtiam = true";
+		static string ipsum = "\tEtiam = true";
 
 
-        static string test(string x, string y) => lorem + delayed(x, y) + ipsum;
+		static string test(string x, string y) => lorem + delayed(x, y) + ipsum;
 
-        [Fact]
-        public void TestDelayedUnit()
-        {
-            var test = DelayedUnitTests.test("5", "10");
-            var parser = Parser.FromContent("", test);
-            var structure = parser.ParseContent("", test);
+		[Fact]
+		public void TestDelayedUnit()
+		{
+			var test = DelayedUnitTests.test("5", "10");
+			var parser = Parser.FromContent("", test);
+			var structure = parser.ParseContent("", test);
 
-            var rec = structure as IUnitRecord;
-            Assert.NotNull(rec);
+			var rec = structure as IUnitRecord;
+			Assert.NotNull(rec);
 
-            var value = rec["Sum"];
-            var unit = value as IUnitValue;
+			var value = rec["Sum"];
+			var unit = value as IUnitValue;
 
-            Assert.NotNull(unit);
+			Assert.NotNull(unit);
 
-            Assert.Equal("15", unit.Value);
+			Assert.Equal("15", unit.Value);
 
-        }
+		}
 
 
-        [Fact]
-        public void TestDelayedUnitParameter()
-        {
-            var test = DelayedUnitTests.test("", "");
+		[Fact]
+		public void TestDelayedUnitParameter()
+		{
+			var test = DelayedUnitTests.test("", "");
 
-            var parser = Parser.FromContent("", test);
-            var structure = parser.ParseContent("", test);
-            var rec = structure as IUnitRecord;
+			var parser = Parser.FromContent("", test);
+			var structure = parser.ParseContent("", test);
+			var rec = structure as IUnitRecord;
 
-            Assert.NotNull(rec);
+			Assert.NotNull(rec);
 
-            var wait = rec["Sum"] as IDelayedUnit;
-            Assert.NotNull(wait);
+			var wait = rec["Sum"] as IDelayedUnit;
+			Assert.NotNull(wait);
 
-            var unit = rec[wait](7, 4) as IUnitValue;
-            Assert.NotNull(unit);
+			var unit = rec[wait](7, 4) as IUnitValue;
+			Assert.NotNull(unit);
 
-            Assert.Equal("11", unit.Value);
+			Assert.Equal("11", unit.Value);
 
-        }
+		}
 
-        [Fact]
-        public void TestNestedDelayedUnit()
-        {
-            var meta = GetMeta('\t', 1, '=', '\'', '"');
-            string nestedDelayed = $$"""
+		[Fact]
+		public void TestNestedDelayedUnit()
+		{
+			var meta = GetMeta('\t', 1, '=', '\'', '"');
+			string nestedDelayed = $$"""
 			NestedTest =
 				{CalculatedValue} = 
 					URL = test://Sum/{OrderQuantity}+{Replacements}
@@ -91,74 +91,106 @@ namespace CclSharp.Test
 					Replacements = 3
 			""";
 
-            string ccl = meta + '\n' + nestedDelayed;
-            var p = Parser.FromContent("", ccl);
-            var rec = p.ParseContent("", ccl) as IUnitRecord;
+			string ccl = meta + '\n' + nestedDelayed;
+			var p = Parser.FromContent("", ccl);
+			var rec = p.ParseContent("", ccl) as IUnitRecord;
 
-            Assert.NotNull(rec);
+			Assert.NotNull(rec);
 
-            Assert.Single(rec.FieldNames);
+			Assert.Single(rec.FieldNames);
 
-            var wait = rec["CalculatedValue"] as IDelayedUnit;
-            Assert.NotNull(wait);
+			var wait = rec["CalculatedValue"] as IDelayedUnit;
+			Assert.NotNull(wait);
 
-            var unit = rec[wait]("JM-323L") as IUnitValue;
-            Assert.NotNull(unit);
+			var unit = rec[wait]("JM-323L") as IUnitValue;
+			Assert.NotNull(unit);
 
-            Assert.Equal("10", unit.Value);
-        }
+			Assert.Equal("10", unit.Value);
+		}
 
-        [Fact]
-        public void TestExpansionQuotedDelayedUnit()
-        {
-            var meta = GetMeta('\t', 1, '=', '\'', '"');
-            var ccl = meta + '\n' +
-            """
+		[Fact]
+		public void TestExpansionQuotedDelayedUnit()
+		{
+			var meta = GetMeta('\t', 1, '=', '\'', '"');
+			var ccl = meta + '\n' +
+			"""
             Order =	
             	{OrderQuantity} = 
             		URL = test://OrderProcessor/"{OrderNumber}"/Quantity
             		OrderNumber =
             """;
 
-            var p = Parser.FromContent("", ccl);
+			var p = Parser.FromContent("", ccl);
 
-            Assert.Equal('"', p.QuoteExpansion);
-            var rec = p.ParseContent("", ccl) as IUnitRecord;
-            Assert.NotNull(rec);
+			Assert.Equal('"', p.QuoteExpansion);
+			var rec = p.ParseContent("", ccl) as IUnitRecord;
+			Assert.NotNull(rec);
 
-            Assert.Single(rec.FieldNames);
+			Assert.Single(rec.FieldNames);
 
-            var wait = rec["OrderQuantity"] as IDelayedUnit;
-            Assert.NotNull(wait);
+			var wait = rec["OrderQuantity"] as IDelayedUnit;
+			Assert.NotNull(wait);
 
-            var unit = rec[wait]("HN/787K") as IUnitValue;
-            Assert.NotNull(unit);
+			var unit = rec[wait]("HN/787K") as IUnitValue;
+			Assert.NotNull(unit);
 
-            Assert.Equal("12", unit.Value);
-        }
-           
-        [Fact]
-        public void MissingPlaceholderFieldsAreAddedAutomatically()
-        {
-            var test = "File=\n\t{FileSize}=\n\t\tURL = test://Sum/5+{y}";
+			Assert.Equal("12", unit.Value);
+		}
 
-            var parser = Parser.FromContent("", test);
-            var structure = parser.ParseContent("", test);
+		[Fact]
+		public void MissingPlaceholderFieldsAreAddedAutomatically()
+		{
+			var test = "File=\n\t{FileSize}=\n\t\tURL = test://Sum/5+{y}";
 
-            var rec = structure as IUnitRecord;
-            Assert.NotNull(rec);
+			var parser = Parser.FromContent("", test);
+			var structure = parser.ParseContent("", test);
 
-            var wait = rec["FileSize"] as IDelayedUnit;
-            Assert.NotNull(wait);
+			var rec = structure as IUnitRecord;
+			Assert.NotNull(rec);
 
-            var unit = rec[wait](15) as IUnitValue;
-            Assert.NotNull(unit);
+			var wait = rec["FileSize"] as IDelayedUnit;
+			Assert.NotNull(wait);
 
-            Assert.Equal("20", unit.Value);
-        }
+			var unit = rec[wait](15) as IUnitValue;
+			Assert.NotNull(unit);
+
+			Assert.Equal("20", unit.Value);
+		}
+
+		[Fact]
+		public void TestResolveDelayedUnit()
+		{
+			var meta = GetMeta('\t', 1, '=', '\'', '"');
+			var ccl = meta + '\n' +
+			"""
+            Order =	
+            	{OrderQuantity} = 
+            		URL = test://OrderProcessor/"{OrderNumber}"/Quantity
+            		OrderNumber =
+            """;
+			var p = Parser.FromContent("", ccl);
+
+			Assert.Equal('"', p.QuoteExpansion);
+			var rec = p.ParseContent("", ccl) as IUnitRecord;
+			Assert.NotNull(rec);
+
+			Assert.Single(rec.FieldNames);
+
+			var wait = rec["OrderQuantity"] as IDelayedUnit;
+			Assert.NotNull(wait);
 
 
+			var orderNumber = "OrderNumber = GB/121F";
+			var import = p.ParseContent("", orderNumber) as IUnitRecord;
+			Assert.NotNull(import);
 
-    }
+			wait = wait.Resolve(import);
+
+			var result = rec[wait]() as IUnitValue;
+			Assert.NotNull(result);
+
+			Assert.Equal("1", result.Value);
+		}
+	}
 }
 

--- a/revision.txt
+++ b/revision.txt
@@ -100,3 +100,9 @@ r15 IResourceProvider and ResourceEngine static class moved into CatConfig CatRe
 r15 Reorganized code files into relevant folders.
 r16	Bug fix - ParserHelpers.Parse next key calculation must happen again after getting a complex value (i.e. record or array) or else 'key' location will be wrong 
 r16	and Parse will fail the level check and exit before finishing.
+r17	IUnitRecord now requires implementation of method Transform(IUnitRecord,bool)->IUnitRecord; which will update values in 'this' where the field name matches some field
+r17	in the provided ('import') IUnitRecord ONLY IF the existing value is 'EmptyUnit' or @override is true, @override is false by default
+r17	IDelayedRecord now requires implementation of method Resolve(IUnitRecord)-> IDelayedUnit, the delayed unit will use the provided record as the 'import' record and will
+r17 pass that record into the Transform method of the DelayedUnit's backing record, the transformed record is used to create a new DelayedUnit which 
+r17	may or may not be fully resolved.
+r17	Added DelayedUnitTests.TestResolveDelayedUnit

--- a/revision.txt
+++ b/revision.txt
@@ -106,3 +106,5 @@ r17	IDelayedRecord now requires implementation of method Resolve(IUnitRecord)-> 
 r17 pass that record into the Transform method of the DelayedUnit's backing record, the transformed record is used to create a new DelayedUnit which 
 r17	may or may not be fully resolved.
 r17	Added DelayedUnitTests.TestResolveDelayedUnit
+r18	UnitRecord no longer performing unnecessary Arity>0 check before resolving delayed unit - caused issues in ResourceConfig "import" functionality
+r18	UnitRecord.Transform ToDictionary string comparer now OrdinalIgnoreCase


### PR DESCRIPTION
r17	IUnitRecord now requires implementation of method Transform(IUnitRecord,bool)->IUnitRecord; which will update values in 'this' where the field name matches some field
r17	in the provided ('import') IUnitRecord ONLY IF the existing value is 'EmptyUnit' or @override is true, @override is false by default
r17	IDelayedRecord now requires implementation of method Resolve(IUnitRecord)-> IDelayedUnit, the delayed unit will use the provided record as the 'import' record and will
r17 pass that record into the Transform method of the DelayedUnit's backing record, the transformed record is used to create a new DelayedUnit which 
r17	may or may not be fully resolved.
r17	Added DelayedUnitTests.TestResolveDelayedUnit
r18	UnitRecord no longer performing unnecessary Arity>0 check before resolving delayed unit - caused issues in ResourceConfig "import" functionality
r18	UnitRecord.Transform ToDictionary string comparer now OrdinalIgnoreCase
